### PR TITLE
Update /non-nextjs-questions to add vercel.community

### DIFF
--- a/content/non-nextjs-questions.mdx
+++ b/content/non-nextjs-questions.mdx
@@ -6,7 +6,7 @@ authors: [joulev]
 
 ## Is there a Vercel discord server?
 
-No, and the Next.js Discord server is focused on Next.js the framework only, not on Vercel the hosting provider, so questions like "How do I fix this error while deploying _SvelteKit_ to Vercel?" are off-topic in the server. For Vercel specific questions we encourage you to seek [suitable Vercel support channels](https://vercel.com/help).
+No, and the Next.js Discord server is focused on Next.js the framework only, not on Vercel the hosting provider, so questions like "How do I fix this error while deploying _SvelteKit_ to Vercel?" are off-topic in the server. For Vercel specific questions we encourage you to seek [suitable Vercel support channels](https://vercel.com/help) or the [official Vercel community](https://vercel.community).
 
 ## How do I report a message or a person in the server to the moderation team?
 


### PR DESCRIPTION
From:
For Vercel specific questions we encourage you to seek [suitable Vercel support channels](https://vercel.com/help).

To:
For Vercel specific questions we encourage you to seek [suitable Vercel support channels](https://vercel.com/help) or the [official Vercel community](https://vercel.community).